### PR TITLE
Update cryptography version in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-cryptography~=36.0.0
+cryptography~=41.0.7
 websockets~=10.2
 asyncclick~=8.0.3.2
 anyio~=3.7.0


### PR DESCRIPTION
To solve [the problem](https://github.com/JezaChen/SSEPy/security/dependabot/2), we upgrade the version of cryptography to 41.0.7.